### PR TITLE
Transitive dependency fixes

### DIFF
--- a/NEOVITAE_API.md
+++ b/NEOVITAE_API.md
@@ -39,12 +39,16 @@ repositories {
 }
 
 dependencies {
-    compileOnly("com.breakinblocks.neovitae:neovitae:1.21.1-1.0.0")
-    runtimeOnly("com.breakinblocks.neovitae:neovitae:1.21.1-1.0.0")
+    compileOnly("com.breakinblocks.neovitae:neovitae:1.21.1-${neoVitaeVersion}")
+    runtimeOnly("com.breakinblocks.neovitae:neovitae:1.21.1-${neoVitaeVersion}")
 }
 ```
 
+You can find the version of the latest released artifact [here](https://maven.breakinblocks.com/#/releases/com/breakinblocks/neovitae/neovitae).
+
 > **Note:** The API classes are in the main mod JAR under `com.breakinblocks.neovitae.api`. There is no separate api artifact.
+
+Although not included by default, it's highly recommended to include the Modonomicon mod in your runtime dependencies.
 
 ### Accessing the API
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Neo Vitae is licensed under the [MIT License](LICENSE.md).
 ## Links
 
 - [Discord](https://discord.gg/TRxaXaYy42)
+- [Modpack Makers Guide](MODPACK_MAKERS.md)
+- [API Guide](NEOVITAE_API.md)
 - [Maven (Releases)](https://maven.breakinblocks.com/releases) - `com.breakinblocks:neovitae`
 - [Maven (Snapshots)](https://maven.breakinblocks.com/snapshots) - `com.breakinblocks:neovitae`
 

--- a/build.gradle
+++ b/build.gradle
@@ -132,16 +132,17 @@ dependencies {
 
     // Jade - WAILA fork for block/entity tooltips (optional dev dependency)
     compileOnly("curse.maven:jade-324717:6853386")
-    runtimeOnly("curse.maven:jade-324717:6853386")
+    localRuntime("curse.maven:jade-324717:6853386")
 
     // Modonomicon - In-game documentation
-    implementation "curse.maven:modonomicon-538392:7771524"
+    compileOnly("curse.maven:modonomicon-538392:7771524")
+    localRuntime("curse.maven:modonomicon-538392:7771524")
 
     compileOnly("mezz.jei:jei-${mc_version}-neoforge-api:${jei_version}")
     compileOnly("top.theillusivec4.curios:curios-neoforge:${curios_version}+${minecraft_version}:api")
 
-    runtimeOnly("mezz.jei:jei-${mc_version}-neoforge:${jei_version}")
-    runtimeOnly("top.theillusivec4.curios:curios-neoforge:${curios_version}+${minecraft_version}")
+    localRuntime("mezz.jei:jei-${mc_version}-neoforge:${jei_version}")
+    localRuntime("top.theillusivec4.curios:curios-neoforge:${curios_version}+${minecraft_version}")
 }
 
 var generateModMetadata = tasks.register("generateModMetadata", ProcessResources) {

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,10 @@ sourceSets {
 
 // API classes are now in the main source set
 
-java.toolchain.languageVersion = JavaLanguageVersion.of(21)
+java {
+    toolchain.languageVersion = JavaLanguageVersion.of(21)
+    withSourcesJar()
+}
 
 neoForge {
     version = project.neo_version

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,11 +1,3 @@
-pluginManagement {
-    repositories {
-        mavenLocal()
-        gradlePluginPortal()
-        maven { url = 'https://maven.neoforged.net/releases' }
-    }
-}
-
 plugins {
     id 'org.gradle.toolchains.foojay-resolver-convention' version '0.10.0'
 }


### PR DESCRIPTION
This pull request adjusts a few things in your build scripts.

First, it removes the plugin management block from the `settings.gradle` file. This is not necessary anymore because MDG is hosted on Maven Central, and all your other plugins are hosted on the Gradle Plugin Portal. Both are included by default in Gradle.

Second, I added links to the modpack and api guides in your README file, as I found them hard to discover.

Third, a link to the Maven has been added to the api guide, as well as a recommendation to add the Modonomicon mod to the runtime environment when depending on NeoVitae.

Lastly, I changed the configuration of a few dependencies to hide them from the Maven POM file. Since the only required dependency is GeckoLib, which is not part of the API, it's exposed as a runtime transitive dependency. That's already covered in the api guide. All the other dependencies were completely stripped from the POM, so depending mods don't try to download them because of a transitive relationship.

I also added a sources JAR task. Hosting the mod on a custom Maven is not really necessary without a sources JAR.

<details>
  <summary>POM before changes</summary>

  ```xml
  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>
    <groupId>com.breakinblocks.neovitae</groupId>
    <artifactId>neovitae</artifactId>
    <version>1.21.1-1.0.0</version>
    <dependencies>
      <dependency>
        <groupId>software.bernie.geckolib</groupId>
        <artifactId>geckolib-neoforge-1.21.1</artifactId>
        <version>4.8.4</version>
        <scope>runtime</scope>
      </dependency>
      <dependency>
        <groupId>curse.maven</groupId>
        <artifactId>modonomicon-538392</artifactId>
        <version>7771524</version>
        <scope>runtime</scope>
      </dependency>
      <dependency>
        <groupId>curse.maven</groupId>
        <artifactId>jade-324717</artifactId>
        <version>6853386</version>
        <scope>runtime</scope>
      </dependency>
      <dependency>
        <groupId>mezz.jei</groupId>
        <artifactId>jei-1.21.1-neoforge</artifactId>
        <version>19.25.1.332</version>
        <scope>runtime</scope>
      </dependency>
      <dependency>
        <groupId>top.theillusivec4.curios</groupId>
        <artifactId>curios-neoforge</artifactId>
        <version>9.4.2+1.21.1</version>
        <scope>runtime</scope>
      </dependency>
    </dependencies>
  </project>
  ```

</details>

<details>
  <summary>POM after changes</summary>

  ```xml
  <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <modelVersion>4.0.0</modelVersion>
    <groupId>com.breakinblocks.neovitae</groupId>
    <artifactId>neovitae</artifactId>
    <version>1.21.1-1.0.0</version>
    <dependencies>
      <dependency>
        <groupId>software.bernie.geckolib</groupId>
        <artifactId>geckolib-neoforge-1.21.1</artifactId>
        <version>4.8.4</version>
        <scope>runtime</scope>
      </dependency>
    </dependencies>
  </project>
  ```

</details>