### PR TITLE
Mark Modonomicon as required

### DIFF
--- a/NEOVITAE_API.md
+++ b/NEOVITAE_API.md
@@ -30,6 +30,12 @@ repositories {
         name = "BreakInBlocks"
         url = "https://maven.breakinblocks.com/releases"
     }
+    // Modonomicon is a transitive dependency of NeoVitae
+    maven {
+        name = "KliKli's maven"
+        url = "https://dl.cloudsmith.io/public/klikli-dev/mods/maven/"
+        content { includeGroup "com.klikli_dev" }
+    }
     // Geckolib is a transitive dependency of NeoVitae
     maven {
         name = "Geckolib"
@@ -39,16 +45,13 @@ repositories {
 }
 
 dependencies {
-    compileOnly("com.breakinblocks.neovitae:neovitae:1.21.1-${neoVitaeVersion}")
-    runtimeOnly("com.breakinblocks.neovitae:neovitae:1.21.1-${neoVitaeVersion}")
+    implementation("com.breakinblocks.neovitae:neovitae:${minecraftVersion}-${neoVitaeVersion}")
 }
 ```
 
 You can find the version of the latest released artifact [here](https://maven.breakinblocks.com/#/releases/com/breakinblocks/neovitae/neovitae).
 
 > **Note:** The API classes are in the main mod JAR under `com.breakinblocks.neovitae.api`. There is no separate api artifact.
-
-Although not included by default, it's highly recommended to include the Modonomicon mod in your runtime dependencies.
 
 ### Accessing the API
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,13 @@ repositories {
         }
     }
     maven {
+        name = "KliKli's maven"
+        url = "https://dl.cloudsmith.io/public/klikli-dev/mods/maven/"
+        content {
+            includeGroup "com.klikli_dev"
+        }
+    }
+    maven {
         // location of the maven that hosts JEI files since January 2023
         name = "Jared's maven"
         url = "https://maven.blamejared.com/"
@@ -134,13 +141,12 @@ dependencies {
     // Geckolib - Animated entity rendering
     implementation("software.bernie.geckolib:geckolib-neoforge-${minecraft_version}:${geckolib_version}")
 
+    // Modonomicon - In-game documentation
+    implementation("com.klikli_dev:modonomicon-${minecraft_version}-neoforge:${modonomicon_version}"){transitive=false}
+
     // Jade - WAILA fork for block/entity tooltips (optional dev dependency)
     compileOnly("curse.maven:jade-324717:6853386")
     localRuntime("curse.maven:jade-324717:6853386")
-
-    // Modonomicon - In-game documentation
-    compileOnly("curse.maven:modonomicon-538392:7771524")
-    localRuntime("curse.maven:modonomicon-538392:7771524")
 
     compileOnly("mezz.jei:jei-${mc_version}-neoforge-api:${jei_version}")
     compileOnly("top.theillusivec4.curios:curios-neoforge:${curios_version}+${minecraft_version}:api")

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,8 +29,6 @@ mc_version=1.21.1
 jei_version=19.25.1.332
 curios_version=9.4.2
 jade_version=15.10.0
-# Patchouli - In-game documentation/guide book
-patchouli_version=1.21.1-92-NEOFORGE
 # Geckolib - Animated entity model rendering
 geckolib_version=4.8.4
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,6 +31,8 @@ curios_version=9.4.2
 jade_version=15.10.0
 # Geckolib - Animated entity model rendering
 geckolib_version=4.8.4
+# Modonomicon - In-game documentation/guide book
+modonomicon_version=1.120.1
 
 ## Mod Properties
 

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -92,6 +92,13 @@ versionRange="*"
 ordering="NONE"
 side="BOTH"
 
+[[dependencies.${mod_id}]]
+modId="modonomicon"
+type="required"
+versionRange="*"
+ordering="NONE"
+side="BOTH"
+
 # Features are specific properties of the game environment, that you may want to declare you require. This example declares
 # that your mod requires GL version 3.2 or higher. Other features will be added. They are side aware so declaring this won't
 # stop your mod loading on the server for example.


### PR DESCRIPTION
This pull request marks Modonomicon as a required dependency and makes it runtime transitive.

In my previous pull request, I considered it an optional dependency since it wasn't mentioned in the mods.toml but since you unconditionally register a guide book item from the mod, it is required.

I updated the TOML file, the build script (switched to the official Maven as well), the API guide, and removed an obsolete patchouli version number.